### PR TITLE
Configure Vercel to use nested Next.js app

### DIFF
--- a/sales-drilldown/src/app/globals.css
+++ b/sales-drilldown/src/app/globals.css
@@ -2,5 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body { height: 100%; }
-body { @apply bg-bgGray; }
+@layer base {
+  html,
+  body {
+    height: 100%;
+  }
+
+  body {
+    background-color: #F7FAFC;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "sales-drilldown/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "sales-drilldown/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- route Vercel builds to `sales-drilldown` subdirectory containing the Next.js application
- ensure requests are forwarded to the correct project path

## Testing
- `npm run build` *(fails: Cannot apply unknown utility class `bg-bgGray`)*

------
https://chatgpt.com/codex/tasks/task_e_68c053d140f48328b5747f70a6e6491b