### PR TITLE
feat: split sales drilldown into four charts

### DIFF
--- a/sales-drilldown/src/app/page.tsx
+++ b/sales-drilldown/src/app/page.tsx
@@ -1,15 +1,16 @@
-import SalesDrilldown from "@/components/SalesDrilldown";
+import SplitDrilldown from "@/components/SplitDrilldown";
 
 export default function Page() {
   return (
     <main className="min-h-screen p-6">
-      <div className="mx-auto max-w-5xl space-y-6">
+      <div className="mx-auto max-w-6xl space-y-6">
         <header className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold text-navy">Sales Drilldown Dashboard</h1>
-          <span className="text-xs px-2 py-1 rounded bg-sky/20 text-navy">Demo</span>
+          <h1 className="text-2xl font-semibold text-gray-900">Sales Drilldown — Split Charts</h1>
+          <span className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700">Demo</span>
         </header>
-        <SalesDrilldown />
+        <SplitDrilldown />
       </div>
     </main>
   );
 }
+

--- a/sales-drilldown/src/components/MetricChart.tsx
+++ b/sales-drilldown/src/components/MetricChart.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import * as echarts from "echarts/core";
+import type { EChartsOption } from "echarts";
+import { LineChart, BarChart } from "echarts/charts";
+import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import { DayMetric, MonthData, SALES } from "@/data/sales";
+import React, { useMemo } from "react";
+
+echarts.use([LineChart, BarChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer]);
+const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+export type ViewState =
+  | { level: "months" }
+  | { level: "weeks"; month: MonthData }
+  | { level: "days"; month: MonthData; weekIdx: number };
+
+type Metric = keyof Omit<DayMetric, "day">;
+
+const METRIC_META: Record<Metric, { label: string; type: "bar" | "line" }> = {
+  signups: { label: "Sign-ups", type: "bar" },
+  cancellations: { label: "Cancellations", type: "bar" },
+  revenue: { label: "Revenue", type: "line" },
+  upsells: { label: "Upsells", type: "line" }
+};
+
+export default function MetricChart({
+  view,
+  metric,
+  onClick
+}: {
+  view: ViewState;
+  metric: Metric;
+  onClick?: (params: { dataIndex: number }) => void;
+}) {
+  const meta = METRIC_META[metric];
+
+  const option = useMemo(() => {
+    if (view.level === "months") {
+      const labels = SALES.map((m) => m.month);
+      const data = SALES.map((m) => m.totals[metric]);
+      return {
+        title: { text: meta.label },
+        tooltip: { trigger: "axis" },
+        xAxis: { type: "category", data: labels },
+        yAxis: { type: "value" },
+        series: [{ name: meta.label, type: meta.type, data, smooth: true, universalTransition: true }]
+      } as EChartsOption;
+    }
+
+    if (view.level === "weeks") {
+      const { month } = view;
+      const labels = month.weeks.map((w) => w.week);
+      const totals = month.weeks.map((w) => w.metrics.reduce((acc, d) => acc + d[metric], 0));
+      return {
+        title: { text: `${meta.label} — ${month.month}` },
+        tooltip: { trigger: "axis" },
+        xAxis: { type: "category", data: labels },
+        yAxis: { type: "value" },
+        series: [{ name: meta.label, type: meta.type, data: totals, smooth: true, universalTransition: true }]
+      } as EChartsOption;
+    }
+
+    // days
+    const { month, weekIdx } = view;
+    const week = month.weeks[weekIdx];
+    const labels = week.metrics.map((d) => d.day);
+    const vals = week.metrics.map((d) => d[metric]);
+    return {
+      title: { text: `${meta.label} — ${month.month} / ${week.week}` },
+      tooltip: { trigger: "axis" },
+      xAxis: { type: "category", data: labels },
+      yAxis: { type: "value" },
+      series: [{ name: meta.label, type: meta.type, data: vals, smooth: true, universalTransition: true }]
+    } as EChartsOption;
+  }, [view, metric, meta.label, meta.type]);
+
+  return (
+    <ReactECharts
+      option={option}
+      style={{ height: 320 }}
+      onEvents={{ click: onClick as (params: unknown) => void }}
+    />
+  );
+}
+

--- a/sales-drilldown/src/components/SplitDrilldown.tsx
+++ b/sales-drilldown/src/components/SplitDrilldown.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { useState } from "react";
+import MetricChart, { ViewState } from "@/components/MetricChart";
+import { SALES } from "@/data/sales";
+
+export default function SplitDrilldown() {
+  const [view, setView] = useState<ViewState>({ level: "months" });
+
+  const onChartClick = (params: { dataIndex: number }) => {
+    if (view.level === "months") {
+      const month = SALES[params.dataIndex];
+      if (month) setView({ level: "weeks", month });
+    } else if (view.level === "weeks") {
+      const { month } = view;
+      setView({ level: "days", month, weekIdx: params.dataIndex });
+    }
+  };
+
+  const canGoBack = view.level !== "months";
+  const goBack = () => {
+    if (view.level === "days") setView({ level: "weeks", month: view.month });
+    else if (view.level === "weeks") setView({ level: "months" });
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-3">
+        {canGoBack && (
+          <button onClick={goBack} className="border rounded px-3 py-1 text-sm hover:bg-gray-50">
+            ← Back
+          </button>
+        )}
+        <div className="text-sm text-gray-600">
+          {view.level === "months" && <span>Level: Months</span>}
+          {view.level === "weeks" && <span>Level: Weeks — {view.month.month}</span>}
+          {view.level === "days" && (
+            <span>
+              Level: Days — {view.month.month} / {view.month.weeks[view.weekIdx].week}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="rounded-lg border bg-white p-3">
+          <MetricChart view={view} metric="signups" onClick={onChartClick} />
+        </div>
+        <div className="rounded-lg border bg-white p-3">
+          <MetricChart view={view} metric="cancellations" onClick={onChartClick} />
+        </div>
+        <div className="rounded-lg border bg-white p-3">
+          <MetricChart view={view} metric="revenue" onClick={onChartClick} />
+        </div>
+        <div className="rounded-lg border bg-white p-3">
+          <MetricChart view={view} metric="upsells" onClick={onChartClick} />
+        </div>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace dashboard page with split drilldown demo
- add reusable MetricChart component for each metric
- implement SplitDrilldown with shared view state across four charts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c06120d0b88328a8202e47ab8e624f