### PR TITLE
feat: generate deterministic sales dataset

### DIFF
--- a/sales-drilldown/src/components/MetricChart.tsx
+++ b/sales-drilldown/src/components/MetricChart.tsx
@@ -17,7 +17,7 @@ export type ViewState =
   | { level: "weeks"; month: MonthData }
   | { level: "days"; month: MonthData; weekIdx: number };
 
-type Metric = keyof Omit<DayMetric, "day">;
+type Metric = keyof Omit<DayMetric, "day" | "dateISO">;
 
 const METRIC_META: Record<Metric, { label: string; type: "bar" | "line" }> = {
   signups: { label: "Sign-ups", type: "bar" },
@@ -53,7 +53,7 @@ export default function MetricChart({
     if (view.level === "weeks") {
       const { month } = view;
       const labels = month.weeks.map((w) => w.week);
-      const totals = month.weeks.map((w) => w.metrics.reduce((acc, d) => acc + d[metric], 0));
+      const totals = month.weeks.map((w) => w.totals[metric]);
       return {
         title: { text: `${meta.label} — ${month.month}` },
         tooltip: { trigger: "axis" },

--- a/sales-drilldown/src/components/SalesDrilldown.tsx
+++ b/sales-drilldown/src/components/SalesDrilldown.tsx
@@ -48,10 +48,10 @@ export default function SalesDrilldown() {
         xAxis: { type: "category", data: labels },
         yAxis: { type: "value" },
         series: [
-          { name: "Sign-ups", type: "bar", data: month.weeks.map((w) => w.metrics.reduce((a, b) => a + b.signups, 0)) },
-          { name: "Cancellations", type: "bar", data: month.weeks.map((w) => w.metrics.reduce((a, b) => a + b.cancellations, 0)) },
-          { name: "Revenue", type: "line", data: month.weeks.map((w) => w.metrics.reduce((a, b) => a + b.revenue, 0)), smooth: true },
-          { name: "Upsells", type: "line", data: month.weeks.map((w) => w.metrics.reduce((a, b) => a + b.upsells, 0)), smooth: true }
+          { name: "Sign-ups", type: "bar", data: month.weeks.map((w) => w.totals.signups) },
+          { name: "Cancellations", type: "bar", data: month.weeks.map((w) => w.totals.cancellations) },
+          { name: "Revenue", type: "line", data: month.weeks.map((w) => w.totals.revenue), smooth: true },
+          { name: "Upsells", type: "line", data: month.weeks.map((w) => w.totals.upsells), smooth: true }
         ]
       } as EChartsOption;
     }

--- a/sales-drilldown/src/data/exportCsv.ts
+++ b/sales-drilldown/src/data/exportCsv.ts
@@ -1,0 +1,14 @@
+import { SALES } from "./sales";
+
+export function toCSV() {
+  const rows = ["dateISO,monthKey,weekIndex,day,signups,cancellations,revenue,upsells"];
+  for (const m of SALES) {
+    for (const w of m.weeks) {
+      for (const d of w.metrics) {
+        rows.push([d.dateISO, m.monthKey, w.weekIndex, d.day, d.signups, d.cancellations, d.revenue, d.upsells].join(","));
+      }
+    }
+  }
+  return rows.join("\n");
+}
+

--- a/sales-drilldown/src/data/sales.config.ts
+++ b/sales-drilldown/src/data/sales.config.ts
@@ -1,0 +1,6 @@
+import { SALES_CONFIG } from "./sales";
+
+// Example: override to 24 months in dev
+SALES_CONFIG.monthsBack = 24;
+SALES_CONFIG.seed = 1337;
+

--- a/sales-drilldown/src/data/sales.ts
+++ b/sales-drilldown/src/data/sales.ts
@@ -1,52 +1,109 @@
-export type DayMetric = { day: string; signups: number; cancellations: number; revenue: number; upsells: number };
-export type WeekData = { week: string; metrics: DayMetric[] };
-export type MonthData = {
-  month: string;
-  totals: { signups: number; cancellations: number; revenue: number; upsells: number };
-  weeks: WeekData[];
+export type DayMetric = { day: string; dateISO: string; signups: number; cancellations: number; revenue: number; upsells: number };
+export type WeekData = { week: string; weekIndex: number; metrics: DayMetric[]; totals: Totals };
+export type MonthData = { month: string; monthKey: string; weeks: WeekData[]; totals: Totals };
+export type Totals = { signups: number; cancellations: number; revenue: number; upsells: number };
+
+// ---- Config
+export const SALES_CONFIG = {
+  monthsBack: 18,               // generate N months ending at current month
+  weeksPerMonthMin: 4,
+  weeksPerMonthMax: 5,
+  seed: 42                      // change for different deterministic series
 };
 
-export const SALES: MonthData[] = [
-  {
-    month: "August 2025",
-    totals: { signups: 1200, cancellations: 150, revenue: 35000, upsells: 320 },
-    weeks: [
-      {
-        week: "Week 1",
-        metrics: [
-          { day: "Mon", signups: 150, cancellations: 15, revenue: 7000, upsells: 60 },
-          { day: "Tue", signups: 180, cancellations: 18, revenue: 8200, upsells: 70 },
-          { day: "Wed", signups: 160, cancellations: 12, revenue: 7500, upsells: 55 },
-          { day: "Thu", signups: 170, cancellations: 14, revenue: 7800, upsells: 65 },
-          { day: "Fri", signups: 160, cancellations: 20, revenue: 8500, upsells: 70 }
-        ]
-      },
-      {
-        week: "Week 2",
-        metrics: [
-          { day: "Mon", signups: 140, cancellations: 10, revenue: 7100, upsells: 50 },
-          { day: "Tue", signups: 175, cancellations: 14, revenue: 8300, upsells: 72 },
-          { day: "Wed", signups: 165, cancellations: 15, revenue: 7600, upsells: 60 },
-          { day: "Thu", signups: 155, cancellations: 18, revenue: 7800, upsells: 62 },
-          { day: "Fri", signups: 170, cancellations: 16, revenue: 8600, upsells: 75 }
-        ]
+// ---- PRNG (xorshift32) for deterministic noise
+function rng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s ^= s << 13; s ^= s >>> 17; s ^= s << 5; // xorshift32
+    return (s >>> 0) / 4294967296;            // [0,1)
+  };
+}
+
+// Helpers
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+const round = (v: number) => Math.round(v);
+
+function monthKey(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth()+1).padStart(2, "0")}`;
+}
+
+function monthLabel(key: string) {
+  const [y, m] = key.split("-").map(Number);
+  return new Date(y, m-1, 1).toLocaleString("en-US", { month: "long", year: "numeric" });
+}
+
+// Seasonal baselines to make data look realistic
+function seasonalBaseline(monthIdx0to11: number) {
+  const season = [1.00, 0.96, 0.98, 1.04, 1.08, 1.10, 1.12, 1.15, 1.10, 1.06, 1.02, 1.00];
+  return season[monthIdx0to11];
+}
+
+// Main generator
+export function generateSales(config = SALES_CONFIG): MonthData[] {
+  const now = new Date();
+  const months: MonthData[] = [];
+  const rand = rng(config.seed);
+
+  for (let i = config.monthsBack - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const mKey = monthKey(d);
+    const mLabel = monthLabel(mKey);
+    const baseline = seasonalBaseline(d.getMonth());
+
+    // Choose 4 or 5 weeks deterministically
+    const weeksCount = config.weeksPerMonthMin + Math.floor(rand() * (config.weeksPerMonthMax - config.weeksPerMonthMin + 1));
+
+    const weeks: WeekData[] = [];
+    const monthTotals: Totals = { signups: 0, cancellations: 0, revenue: 0, upsells: 0 };
+
+    for (let w = 0; w < weeksCount; w++) {
+      const metrics: DayMetric[] = [];
+      const weekTotals: Totals = { signups: 0, cancellations: 0, revenue: 0, upsells: 0 };
+
+      for (let dIdx = 0; dIdx < 7; dIdx++) {
+        // Baseline daily values with randomness
+        const weekdayBoost = dIdx <= 4 ? 1.10 : 0.75; // weekdays vs weekends
+        const noise = 0.85 + rand() * 0.3;            // 0.85..1.15
+
+        const signups = round(clamp(80 * baseline * weekdayBoost * noise, 20, 450));
+        const cancellations = round(clamp(signups * (0.06 + rand() * 0.06), 0, Math.max(5, signups * 0.5)));
+        const upsells = round(clamp(signups * (0.25 + rand() * 0.20), 0, signups));
+        const arpu = 35 + rand() * 25;                // $35-$60
+        const revenue = round((signups - cancellations) * arpu + upsells * (10 + rand() * 30));
+
+        const date = new Date(d.getFullYear(), d.getMonth(), 1 + w * 7 + dIdx);
+        const rec: DayMetric = {
+          day: DAY_NAMES[dIdx],
+          dateISO: date.toISOString().slice(0, 10),
+          signups,
+          cancellations,
+          revenue,
+          upsells
+        };
+        metrics.push(rec);
+
+        weekTotals.signups += signups;
+        weekTotals.cancellations += cancellations;
+        weekTotals.revenue += revenue;
+        weekTotals.upsells += upsells;
       }
-    ]
-  },
-  {
-    month: "September 2025",
-    totals: { signups: 1350, cancellations: 200, revenue: 40000, upsells: 360 },
-    weeks: [
-      {
-        week: "Week 1",
-        metrics: [
-          { day: "Mon", signups: 200, cancellations: 25, revenue: 9500, upsells: 80 },
-          { day: "Tue", signups: 210, cancellations: 22, revenue: 10200, upsells: 85 },
-          { day: "Wed", signups: 190, cancellations: 20, revenue: 9700, upsells: 78 },
-          { day: "Thu", signups: 220, cancellations: 24, revenue: 11000, upsells: 90 },
-          { day: "Fri", signups: 190, cancellations: 18, revenue: 9600, upsells: 80 }
-        ]
-      }
-    ]
+
+      weeks.push({ week: `Week ${w+1}`, weekIndex: w, metrics, totals: weekTotals });
+
+      monthTotals.signups += weekTotals.signups;
+      monthTotals.cancellations += weekTotals.cancellations;
+      monthTotals.revenue += weekTotals.revenue;
+      monthTotals.upsells += weekTotals.upsells;
+    }
+
+    months.push({ month: mLabel, monthKey: mKey, weeks, totals: monthTotals });
   }
-];
+
+  return months;
+}
+
+// Eagerly generate (deterministic) dataset for importers
+export const SALES: MonthData[] = generateSales();
+


### PR DESCRIPTION
## Summary
- replace hardcoded SALES with seeded generator producing months/weeks/days and precomputed totals
- update charts to use precomputed weekly totals and exclude date field
- add optional config overrides and CSV export utility

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c062e7f66483289750a09d12a8a808