### PR TITLE
feat: add independent drilldown charts

### DIFF
--- a/sales-drilldown/src/app/page.tsx
+++ b/sales-drilldown/src/app/page.tsx
@@ -1,16 +1,15 @@
-import SplitDrilldown from "@/components/SplitDrilldown";
+import IndependentGrid from "@/components/IndependentGrid";
 
 export default function Page() {
   return (
     <main className="min-h-screen p-6">
       <div className="mx-auto max-w-6xl space-y-6">
         <header className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold text-gray-900">Sales Drilldown — Split Charts</h1>
+          <h1 className="text-2xl font-semibold text-gray-900">Sales Drilldown — Independent Charts (Years → Days)</h1>
           <span className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700">Demo</span>
         </header>
-        <SplitDrilldown />
+        <IndependentGrid />
       </div>
     </main>
   );
 }
-

--- a/sales-drilldown/src/components/IndependentGrid.tsx
+++ b/sales-drilldown/src/components/IndependentGrid.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import IndependentMetricChart from "@/components/IndependentMetricChart";
+
+export default function IndependentGrid() {
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <IndependentMetricChart metric="signups" />
+        <IndependentMetricChart metric="cancellations" />
+        <IndependentMetricChart metric="revenue" />
+        <IndependentMetricChart metric="upsells" />
+      </div>
+    </section>
+  );
+}

--- a/sales-drilldown/src/components/IndependentMetricChart.tsx
+++ b/sales-drilldown/src/components/IndependentMetricChart.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import * as echarts from "echarts/core";
+import type { EChartsOption } from "echarts";
+import { LineChart, BarChart } from "echarts/charts";
+import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import React, { useMemo, useState } from "react";
+import { SALES, MonthData, YearBucket, groupByYear, monthShortLabel, Totals } from "@/data/sales";
+
+echarts.use([LineChart, BarChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer]);
+const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+type Metric = keyof Totals;
+const META: Record<Metric, { label: string; type: "bar" | "line" }> = {
+  signups: { label: "Sign-ups", type: "bar" },
+  cancellations: { label: "Cancellations", type: "bar" },
+  revenue: { label: "Revenue", type: "line" },
+  upsells: { label: "Upsells", type: "line" }
+};
+
+type View =
+  | { level: "years"; years: YearBucket[] }
+  | { level: "months"; year: YearBucket }
+  | { level: "weeks"; month: MonthData }
+  | { level: "days"; month: MonthData; weekIdx: number };
+
+export default function IndependentMetricChart({ metric }: { metric: Metric }) {
+  // Initial: aggregate by year
+  const [view, setView] = useState<View>({ level: "years", years: groupByYear(SALES) });
+  const meta = META[metric];
+
+  const option = useMemo(() => {
+    if (view.level === "years") {
+      const labels = view.years.map((y) => y.yearKey);
+      const data = view.years.map((y) => y.totals[metric]);
+      return {
+        title: { text: meta.label },
+        tooltip: { trigger: "axis" },
+        xAxis: { type: "category", data: labels },
+        yAxis: { type: "value" },
+        series: [{ name: meta.label, type: meta.type, data, smooth: true, universalTransition: true }]
+      } as EChartsOption;
+    }
+    if (view.level === "months") {
+      const labels = view.year.months.map((m) => monthShortLabel(m.monthKey));
+      const data = view.year.months.map((m) => m.totals[metric]);
+      return {
+        title: { text: `${meta.label} — ${view.year.yearKey}` },
+        tooltip: { trigger: "axis" },
+        xAxis: { type: "category", data: labels },
+        yAxis: { type: "value" },
+        series: [{ name: meta.label, type: meta.type, data, smooth: true, universalTransition: true }]
+      } as EChartsOption;
+    }
+    if (view.level === "weeks") {
+      const labels = view.month.weeks.map((w) => w.week);
+      const data = view.month.weeks.map((w) => w.totals[metric]);
+      return {
+        title: { text: `${meta.label} — ${view.month.month}` },
+        tooltip: { trigger: "axis" },
+        xAxis: { type: "category", data: labels },
+        yAxis: { type: "value" },
+        series: [{ name: meta.label, type: meta.type, data, smooth: true, universalTransition: true }]
+      } as EChartsOption;
+    }
+    // days
+    const week = view.month.weeks[view.weekIdx];
+    const labels = week.metrics.map((d) => d.day);
+    const data = week.metrics.map((d) => d[metric]);
+    return {
+      title: { text: `${meta.label} — ${view.month.month} / ${week.week}` },
+      tooltip: { trigger: "axis" },
+      xAxis: { type: "category", data: labels },
+      yAxis: { type: "value" },
+      series: [{ name: meta.label, type: meta.type, data, smooth: true, universalTransition: true }]
+    } as EChartsOption;
+  }, [view, metric, meta.label, meta.type]);
+
+  const onClick = (params: { dataIndex: number }) => {
+    if (view.level === "years") {
+      const idx = params.dataIndex;
+      const year = view.years[idx];
+      if (year) setView({ level: "months", year });
+    } else if (view.level === "months") {
+      const month = view.year.months[params.dataIndex];
+      if (month) setView({ level: "weeks", month });
+    } else if (view.level === "weeks") {
+      setView({ level: "days", month: view.month, weekIdx: params.dataIndex });
+    }
+  };
+
+  const reset = () => setView({ level: "years", years: groupByYear(SALES) });
+
+  // Breadcrumbs
+  let crumb = "Years";
+  if (view.level === "months") crumb = `${view.year.yearKey}`;
+  if (view.level === "weeks") crumb = `${view.month.monthKey.slice(0,4)} › ${monthShortLabel(view.month.monthKey)}`;
+  if (view.level === "days") crumb = `${view.month.monthKey.slice(0,4)} › ${monthShortLabel(view.month.monthKey)} › ${view.month.weeks[view.weekIdx].week}`;
+
+  return (
+    <div className="rounded-lg border bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-sm text-gray-600">{crumb}</div>
+        <button onClick={reset} className="text-xs border rounded px-2 py-1 hover:bg-gray-50">Reset</button>
+      </div>
+      <ReactECharts option={option} style={{ height: 320 }} onEvents={{ click: onClick }} />
+    </div>
+  );
+}

--- a/sales-drilldown/src/data/sales.ts
+++ b/sales-drilldown/src/data/sales.ts
@@ -107,3 +107,28 @@ export function generateSales(config = SALES_CONFIG): MonthData[] {
 // Eagerly generate (deterministic) dataset for importers
 export const SALES: MonthData[] = generateSales();
 
+// === Aggregation helpers for Years → Months → Weeks → Days ===
+export type YearKey = string; // e.g., "2024"
+export type YearBucket = { yearKey: YearKey; months: MonthData[]; totals: Totals };
+
+export function groupByYear(months: MonthData[]): YearBucket[] {
+  const byYear = new Map<YearKey, { months: MonthData[]; totals: Totals }>();
+  for (const m of months) {
+    const y = m.monthKey.slice(0, 4);
+    const curr = byYear.get(y) ?? { months: [], totals: { signups: 0, cancellations: 0, revenue: 0, upsells: 0 } };
+    curr.months.push(m);
+    curr.totals.signups += m.totals.signups;
+    curr.totals.cancellations += m.totals.cancellations;
+    curr.totals.revenue += m.totals.revenue;
+    curr.totals.upsells += m.totals.upsells;
+    byYear.set(y, curr);
+  }
+  return Array.from(byYear.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([yearKey, v]) => ({ yearKey, months: v.months.sort((a, b) => a.monthKey.localeCompare(b.monthKey)), totals: v.totals }));
+}
+
+export function monthShortLabel(monthKey: string): string {
+  const [y, m] = monthKey.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleString("en-US", { month: "short" });
+}


### PR DESCRIPTION
## Summary
- add year and month aggregation helpers to sales data
- introduce independent metric chart component with per-panel drilldown and breadcrumbs
- display four independent charts on home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06e75daec8328ad65d946357b2944