### PR TITLE
feat: drill down to minutes with independent sales panels

### DIFF
--- a/sales-drilldown/src/app/page.tsx
+++ b/sales-drilldown/src/app/page.tsx
@@ -1,14 +1,14 @@
-import IndependentGrid from "@/components/IndependentGrid";
+import DeepGrid from "@/components/DeepGrid";
 
 export default function Page() {
   return (
     <main className="min-h-screen p-6">
       <div className="mx-auto max-w-6xl space-y-6">
         <header className="flex items-center gap-3">
-          <h1 className="text-2xl font-semibold text-gray-900">Sales Drilldown — Independent Charts (Years → Days)</h1>
+          <h1 className="text-2xl font-semibold">Sales Drilldown — Years → Minutes (Independent Panels)</h1>
           <span className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700">Demo</span>
         </header>
-        <IndependentGrid />
+        <DeepGrid />
       </div>
     </main>
   );

--- a/sales-drilldown/src/components/DeepGrid.tsx
+++ b/sales-drilldown/src/components/DeepGrid.tsx
@@ -1,0 +1,16 @@
+"use client";
+import DeepMetricPanel from "@/components/DeepMetricPanel";
+
+export default function DeepGrid(){
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <DeepMetricPanel metric="signups" />
+        <DeepMetricPanel metric="cancellations" />
+        <DeepMetricPanel metric="revenue" />
+        <DeepMetricPanel metric="upsells" />
+      </div>
+    </section>
+  );
+}
+

--- a/sales-drilldown/src/components/DeepMetricPanel.tsx
+++ b/sales-drilldown/src/components/DeepMetricPanel.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import * as echarts from "echarts/core";
+import { LineChart, BarChart } from "echarts/charts";
+import { GridComponent, TooltipComponent, LegendComponent, TitleComponent, DataZoomComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import React, { useMemo, useState } from "react";
+import {
+  SALES,
+  Totals,
+  MonthData,
+  YearBucket,
+  QuarterBucket,
+  groupByYear,
+  groupByQuarter,
+  monthShortLabel,
+  daysOfMonth,
+  synthesizeHours,
+  synthesizeMinutes,
+  findMonth
+} from "@/data/sales";
+
+echarts.use([LineChart, BarChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, DataZoomComponent, CanvasRenderer]);
+const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
+
+type Metric = keyof Totals; // "signups" | "cancellations" | "revenue" | "upsells"
+const META: Record<Metric, { label: string; type: "bar" | "line" }> = {
+  signups: { label: "Sign-ups", type: "bar" },
+  cancellations: { label: "Cancellations", type: "bar" },
+  revenue: { label: "Revenue", type: "line" },
+  upsells: { label: "Upsells", type: "line" }
+};
+
+type View =
+  | { level: "years"; years: YearBucket[] }
+  | { level: "quarters"; year: YearBucket; quarters: QuarterBucket[] }
+  | { level: "months"; quarter: QuarterBucket }
+  | { level: "weeks"; month: MonthData }
+  | { level: "days"; month: MonthData }
+  | { level: "hours"; dayISO: string; dayTotal: number }
+  | { level: "minutes"; dayISO: string; hour: number; hourTotal: number };
+
+export default function DeepMetricPanel({ metric }: { metric: Metric }) {
+  const meta = META[metric];
+  const [view, setView] = useState<View>({ level: "years", years: groupByYear(SALES) });
+
+  const option = useMemo(() => {
+    if (view.level === "years") {
+      const labels = view.years.map(y=>y.yearKey);
+      const data = view.years.map(y=> y.totals[metric]);
+      return { title:{text: meta.label}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true, universalTransition:true }] } as echarts.EChartsCoreOption;
+    }
+    if (view.level === "quarters") {
+      const labels = view.quarters.map(q=> q.quarterKey.split('-')[1]);
+      const data = view.quarters.map(q=> q.totals[metric]);
+      return { title:{text: `${meta.label} — ${view.year.yearKey}`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true, universalTransition:true }] } as echarts.EChartsCoreOption;
+    }
+    if (view.level === "months") {
+      const labels = view.quarter.months.map(m=> monthShortLabel(m.monthKey));
+      const data = view.quarter.months.map(m=> m.totals[metric]);
+      return { title:{text: `${meta.label} — ${view.quarter.quarterKey}`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true, universalTransition:true }] } as echarts.EChartsCoreOption;
+    }
+    if (view.level === "weeks") {
+      const labels = view.month.weeks.map(w=> w.week);
+      const data = view.month.weeks.map(w=> w.totals[metric]);
+      return { title:{text: `${meta.label} — ${view.month.month}`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true, universalTransition:true }] } as echarts.EChartsCoreOption;
+    }
+    if (view.level === "days") {
+      const days = daysOfMonth(view.month);
+      const labels = days.map(d=> d.dateISO.slice(8,10));
+      const data = days.map(d=> d.totals[metric]);
+      return { title:{text: `${meta.label} — ${view.month.month}`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, dataZoom:[{type:"inside"},{type:"slider"}], series:[{ name: meta.label, type: meta.type, data, smooth:true, universalTransition:true }] } as echarts.EChartsCoreOption;
+    }
+    if (view.level === "hours") {
+      const hours = synthesizeHours(view.dayISO, metric, view.dayTotal);
+      const labels = hours.map(h=> String(h.hour));
+      const data = hours.map(h=> h.value);
+      return { title:{text: `${meta.label} — ${view.dayISO}`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true }] } as echarts.EChartsCoreOption;
+    }
+    // minutes
+    const minutes = synthesizeMinutes(view.dayISO, view.hour, metric, view.hourTotal);
+    const labels = minutes.map(m=> String(m.minute));
+    const data = minutes.map(m=> m.value);
+    return { title:{text: `${meta.label} — ${view.dayISO} ${String(view.hour).padStart(2,'0')}:00`}, tooltip:{trigger:"axis"}, xAxis:{type:"category",data:labels}, yAxis:{type:"value"}, series:[{ name: meta.label, type: meta.type, data, smooth:true }] } as echarts.EChartsCoreOption;
+  }, [view, metric, meta.label, meta.type]);
+
+  const onClick = (params: { dataIndex: number }) => {
+    if (view.level === "years") {
+      const year = view.years[params.dataIndex];
+      if (year) setView({ level: "quarters", year, quarters: groupByQuarter(year) });
+    } else if (view.level === "quarters") {
+      const quarter = view.quarters[params.dataIndex];
+      if (quarter) setView({ level: "months", quarter });
+    } else if (view.level === "months") {
+      const month = view.quarter.months[params.dataIndex];
+      if (month) setView({ level: "weeks", month });
+    } else if (view.level === "weeks") {
+      const month = view.month; // select the week to go to days view (show whole month days by default)
+      setView({ level: "days", month });
+    } else if (view.level === "days") {
+      const days = daysOfMonth(view.month);
+      const day = days[params.dataIndex];
+      if (day) setView({ level: "hours", dayISO: day.dateISO, dayTotal: day.totals[metric] });
+    } else if (view.level === "hours") {
+      const hours = synthesizeHours(view.dayISO, metric, view.dayTotal);
+      const h = hours[params.dataIndex];
+      if (h) setView({ level: "minutes", dayISO: view.dayISO, hour: h.hour, hourTotal: h.value });
+    }
+  };
+
+  const back = () => {
+    if (view.level === "minutes") setView({ level: "hours", dayISO: view.dayISO, dayTotal: view.hourTotal });
+    else if (view.level === "hours") setView({ level: "days", month: findMonth(view.dayISO.slice(0,7), SALES)! });
+    else if (view.level === "days") setView({ level: "weeks", month: view.month });
+    else if (view.level === "weeks") setView({ level: "months", quarter: groupByQuarter({ yearKey: view.month.monthKey.slice(0,4), months: SALES.filter(m=>m.monthKey.startsWith(view.month.monthKey.slice(0,7).slice(0,4))), totals: {signups:0,cancellations:0,revenue:0,upsells:0} })[Math.floor((Number(view.month.monthKey.slice(5,7))-1)/3)] });
+    else if (view.level === "months") setView({ level: "quarters", year: { yearKey: view.quarter.quarterKey.slice(0,4), months: SALES.filter(m=>m.monthKey.startsWith(view.quarter.quarterKey.slice(0,4))), totals: {signups:0,cancellations:0,revenue:0,upsells:0} }, quarters: groupByQuarter({ yearKey: view.quarter.quarterKey.slice(0,4), months: SALES.filter(m=>m.monthKey.startsWith(view.quarter.quarterKey.slice(0,4))), totals: {signups:0,cancellations:0,revenue:0,upsells:0} }) });
+    else if (view.level === "quarters") setView({ level: "years", years: groupByYear(SALES) });
+  };
+
+  const reset = () => setView({ level: "years", years: groupByYear(SALES) });
+
+  // Breadcrumb label
+  const crumb = (()=>{
+    switch(view.level){
+      case "years": return "Years";
+      case "quarters": return `${view.year.yearKey}`;
+      case "months": return `${view.quarter.quarterKey}`;
+      case "weeks": return `${view.month.monthKey.slice(0,4)} › ${monthShortLabel(view.month.monthKey)}`;
+      case "days": return `${view.month.month}`;
+      case "hours": return `${view.dayISO}`;
+      case "minutes": return `${view.dayISO} › ${String(view.hour).padStart(2,'0')}:00`;
+    }
+  })();
+
+  return (
+    <div className="rounded-lg border bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-sm text-gray-600">{crumb}</div>
+        <div className="flex items-center gap-2">
+          <button onClick={back} className="text-xs border rounded px-2 py-1 hover:bg-gray-50">Back</button>
+          <button onClick={reset} className="text-xs border rounded px-2 py-1 hover:bg-gray-50">Reset</button>
+        </div>
+      </div>
+      <ReactECharts option={option} style={{ height: 320 }} onEvents={{ click: onClick }} />
+    </div>
+  );
+}
+

--- a/sales-drilldown/src/data/sales.ts
+++ b/sales-drilldown/src/data/sales.ts
@@ -107,28 +107,108 @@ export function generateSales(config = SALES_CONFIG): MonthData[] {
 // Eagerly generate (deterministic) dataset for importers
 export const SALES: MonthData[] = generateSales();
 
-// === Aggregation helpers for Years → Months → Weeks → Days ===
-export type YearKey = string; // e.g., "2024"
+// ---- Deep time helpers (append to src/data/sales.ts)
+export type YearKey = string; // "2025"
+export type QuarterKey = `${YearKey}-Q${1|2|3|4}`;
+export type DayISO = string; // YYYY-MM-DD
+
 export type YearBucket = { yearKey: YearKey; months: MonthData[]; totals: Totals };
+export type QuarterBucket = { quarterKey: QuarterKey; months: MonthData[]; totals: Totals };
 
 export function groupByYear(months: MonthData[]): YearBucket[] {
-  const byYear = new Map<YearKey, { months: MonthData[]; totals: Totals }>();
+  const map = new Map<YearKey, YearBucket>();
   for (const m of months) {
     const y = m.monthKey.slice(0, 4);
-    const curr = byYear.get(y) ?? { months: [], totals: { signups: 0, cancellations: 0, revenue: 0, upsells: 0 } };
-    curr.months.push(m);
-    curr.totals.signups += m.totals.signups;
-    curr.totals.cancellations += m.totals.cancellations;
-    curr.totals.revenue += m.totals.revenue;
-    curr.totals.upsells += m.totals.upsells;
-    byYear.set(y, curr);
+    const b = map.get(y) ?? { yearKey: y, months: [], totals: { signups:0,cancellations:0,revenue:0,upsells:0 } };
+    b.months.push(m);
+    b.totals.signups += m.totals.signups;
+    b.totals.cancellations += m.totals.cancellations;
+    b.totals.revenue += m.totals.revenue;
+    b.totals.upsells += m.totals.upsells;
+    map.set(y, b);
   }
-  return Array.from(byYear.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([yearKey, v]) => ({ yearKey, months: v.months.sort((a, b) => a.monthKey.localeCompare(b.monthKey)), totals: v.totals }));
+  return Array.from(map.values()).sort((a,b)=>a.yearKey.localeCompare(b.yearKey));
+}
+
+export function groupByQuarter(year: YearBucket): QuarterBucket[] {
+  const qMap = new Map<QuarterKey, QuarterBucket>();
+  for (const m of year.months) {
+    const y = year.yearKey;
+    const monthIdx = Number(m.monthKey.slice(5,7)) - 1; // 0-11
+    const q = (Math.floor(monthIdx/3)+1) as 1|2|3|4;
+    const qk = `${y}-Q${q}` as QuarterKey;
+    const b = qMap.get(qk) ?? { quarterKey: qk, months: [], totals: { signups:0,cancellations:0,revenue:0,upsells:0 } };
+    b.months.push(m);
+    b.totals.signups += m.totals.signups;
+    b.totals.cancellations += m.totals.cancellations;
+    b.totals.revenue += m.totals.revenue;
+    b.totals.upsells += m.totals.upsells;
+    qMap.set(qk, b);
+  }
+  return Array.from(qMap.values()).sort((a,b)=>a.quarterKey.localeCompare(b.quarterKey));
 }
 
 export function monthShortLabel(monthKey: string): string {
-  const [y, m] = monthKey.split("-").map(Number);
-  return new Date(y, m - 1, 1).toLocaleString("en-US", { month: "short" });
+  const [y,m] = monthKey.split('-').map(Number);
+  return new Date(y, m-1, 1).toLocaleString('en-US', { month: 'short' });
 }
+
+export function dayISO(y:number,m:number,d:number){
+  return new Date(y, m-1, d).toISOString().slice(0,10);
+}
+
+// Locate a MonthData by key
+export function findMonth(monthKey: string, months: MonthData[]): MonthData | undefined {
+  return months.find(m=>m.monthKey===monthKey);
+}
+
+// Flatten selected MonthData to list of calendar days (with totals per day)
+export function daysOfMonth(month: MonthData): { dateISO: DayISO; label: string; totals: Totals }[] {
+  const out: { dateISO: DayISO; label: string; totals: Totals }[] = [];
+  for (const w of month.weeks) {
+    for (const d of w.metrics) {
+      out.push({
+        dateISO: d.dateISO,
+        label: d.day,
+        totals: { signups: d.signups, cancellations: d.cancellations, revenue: d.revenue, upsells: d.upsells }
+      });
+    }
+  }
+  // sort by dateISO to keep calendar order
+  out.sort((a,b)=>a.dateISO.localeCompare(b.dateISO));
+  return out;
+}
+
+// --- Lazy hour/minute synthesis per day (deterministic)
+function lazyRng(seed:number){ let s=seed|0; return ()=>{ s^=s<<13; s^=s>>>17; s^=s<<5; return (s>>>0)/4294967296; }; }
+function seedFromISO(iso: string, metric: string){
+  // simple hash seed from string
+  let h = 2166136261;
+  const str = iso+"/"+metric;
+  for(let i=0;i<str.length;i++){ h ^= str.charCodeAt(i); h += (h<<1)+(h<<4)+(h<<7)+(h<<8)+(h<<24); }
+  return h|0;
+}
+
+export type HourPoint = { hour: number; value: number };
+export type MinutePoint = { minute: number; value: number };
+
+// Split a day total across 24 hours with light variance; returns normalized to ~dayTotal
+export function synthesizeHours(dayISO: DayISO, metric: keyof Totals, dayTotal: number): HourPoint[] {
+  const r = lazyRng(seedFromISO(dayISO, String(metric)));
+  // diurnal pattern: peak mid‑day, dip at night
+  const weights = Array.from({length:24}, (_,h)=> 0.6 + 0.8*Math.exp(-Math.pow((h-14)/6,2)) + r()*0.15);
+  const sum = weights.reduce((a,b)=>a+b,0);
+  const scale = dayTotal / Math.max(sum, 1e-6);
+  return weights.map((w,h)=>({ hour:h, value: Math.max(0, Math.round(w*scale)) }));
+}
+
+// Split an hour total across 60 minutes with small randomness; normalized to ~hourTotal
+export function synthesizeMinutes(dayISO: DayISO, hour: number, metric: keyof Totals, hourTotal: number): MinutePoint[] {
+  const r = lazyRng(seedFromISO(`${dayISO}T${String(hour).padStart(2,'0')}:00`, String(metric)));
+  const weights = Array.from({length:60}, ()=> 0.9 + r()*0.2);
+  const sum = weights.reduce((a,b)=>a+b,0);
+  const scale = hourTotal / Math.max(sum, 1e-6);
+  return weights.map((w,i)=>({ minute:i, value: Math.max(0, Math.round(w*scale)) }));
+}
+
+


### PR DESCRIPTION
## Summary
- add deep time helpers for year-to-minute drill downs and lazy hour/minute synthesis
- implement DeepMetricPanel with independent breadcrumb navigation and reset/back actions
- update dashboard to show four independent metric panels with deep drilldown

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0758fddcc8328a2895127ffc73917