### PR TITLE
feat: color chart lines by trend

### DIFF
--- a/sales-drilldown/src/components/DeepMetricPanel.tsx
+++ b/sales-drilldown/src/components/DeepMetricPanel.tsx
@@ -21,6 +21,7 @@ import {
   findMonth
 } from "@/data/sales";
 import { METRICS, MetricKey, MetricMeta } from "@/data/metrics";
+import { trendColor } from "@/utils/trendColor";
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, DataZoomComponent, CanvasRenderer]);
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
@@ -52,12 +53,6 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
   const calcDay = useCallback((t: Totals) => meta.dayFormula(t, dayCtx(t)), [meta]);
 
   const option = useMemo(() => {
-    const lineColor = (vals: number[]) => (p: { dataIndex: number }) => {
-      const i = p.dataIndex;
-      if (i >= vals.length - 1) return "#000";
-      return vals[i + 1] >= vals[i] ? "#000" : "#f00";
-    };
-
     if (view.level === "years") {
       const labels = view.years.map(y=>y.yearKey);
       const data = view.years.map(y=>{
@@ -77,7 +72,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           universalTransition:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -101,7 +96,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           universalTransition:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -125,7 +120,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           universalTransition:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -149,7 +144,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           universalTransition:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -172,7 +167,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           universalTransition:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -193,7 +188,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           smooth:true,
           showSymbol:false,
           lineStyle:{
-            color: lineColor(data)
+            color: trendColor(data)
           }
         }]
       } as echarts.EChartsCoreOption;
@@ -213,7 +208,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         smooth:true,
         showSymbol:false,
         lineStyle:{
-          color: lineColor(data)
+          color: trendColor(data)
         }
       }]
     } as echarts.EChartsCoreOption;

--- a/sales-drilldown/src/components/IndependentMetricChart.tsx
+++ b/sales-drilldown/src/components/IndependentMetricChart.tsx
@@ -8,6 +8,7 @@ import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from
 import { CanvasRenderer } from "echarts/renderers";
 import React, { useMemo, useState } from "react";
 import { SALES, MonthData, YearBucket, groupByYear, monthShortLabel, Totals } from "@/data/sales";
+import { trendColor } from "@/utils/trendColor";
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer]);
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
@@ -49,11 +50,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
             universalTransition: true,
             showSymbol: false,
             lineStyle: {
-              color: (p: { dataIndex: number }) => {
-                const i = p.dataIndex;
-                if (i >= values.length - 1) return "#000";
-                return values[i + 1] >= values[i] ? "#000" : "#f00";
-              }
+              color: trendColor(values)
             }
           }
         ]
@@ -76,11 +73,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
             universalTransition: true,
             showSymbol: false,
             lineStyle: {
-              color: (p: { dataIndex: number }) => {
-                const i = p.dataIndex;
-                if (i >= values.length - 1) return "#000";
-                return values[i + 1] >= values[i] ? "#000" : "#f00";
-              }
+              color: trendColor(values)
             }
           }
         ]
@@ -103,11 +96,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
             universalTransition: true,
             showSymbol: false,
             lineStyle: {
-              color: (p: { dataIndex: number }) => {
-                const i = p.dataIndex;
-                if (i >= values.length - 1) return "#000";
-                return values[i + 1] >= values[i] ? "#000" : "#f00";
-              }
+              color: trendColor(values)
             }
           }
         ]
@@ -131,11 +120,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           universalTransition: true,
           showSymbol: false,
           lineStyle: {
-            color: (p: { dataIndex: number }) => {
-              const i = p.dataIndex;
-              if (i >= values.length - 1) return "#000";
-              return values[i + 1] >= values[i] ? "#000" : "#f00";
-            }
+            color: trendColor(values)
           }
         }
       ]

--- a/sales-drilldown/src/components/MetricChart.tsx
+++ b/sales-drilldown/src/components/MetricChart.tsx
@@ -8,6 +8,7 @@ import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from
 import { CanvasRenderer } from "echarts/renderers";
 import { DayMetric, MonthData, SALES } from "@/data/sales";
 import React, { useMemo } from "react";
+import { trendColor } from "@/utils/trendColor";
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer]);
 const ReactECharts = dynamic(() => import("echarts-for-react"), { ssr: false });
@@ -55,11 +56,7 @@ export default function MetricChart({
             universalTransition: true,
             showSymbol: false,
             lineStyle: {
-              color: (p: { dataIndex: number }) => {
-                const i = p.dataIndex;
-                if (i >= values.length - 1) return "#000";
-                return values[i + 1] >= values[i] ? "#000" : "#f00";
-              }
+              color: trendColor(values)
             }
           }
         ]
@@ -84,11 +81,7 @@ export default function MetricChart({
             universalTransition: true,
             showSymbol: false,
             lineStyle: {
-              color: (p: { dataIndex: number }) => {
-                const i = p.dataIndex;
-                if (i >= totals.length - 1) return "#000";
-                return totals[i + 1] >= totals[i] ? "#000" : "#f00";
-              }
+              color: trendColor(totals)
             }
           }
         ]
@@ -114,11 +107,7 @@ export default function MetricChart({
           universalTransition: true,
           showSymbol: false,
           lineStyle: {
-            color: (p: { dataIndex: number }) => {
-              const i = p.dataIndex;
-              if (i >= vals.length - 1) return "#000";
-              return vals[i + 1] >= vals[i] ? "#000" : "#f00";
-            }
+            color: trendColor(vals)
           }
         }
       ]

--- a/sales-drilldown/src/components/SalesDrilldown.tsx
+++ b/sales-drilldown/src/components/SalesDrilldown.tsx
@@ -8,6 +8,7 @@ import { LineChart } from "echarts/charts";
 import { GridComponent, TooltipComponent, LegendComponent, TitleComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import { SALES, MonthData } from "@/data/sales";
+import { trendColor } from "@/utils/trendColor";
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent, CanvasRenderer]);
 
@@ -28,11 +29,7 @@ export default function SalesDrilldown() {
       smooth: true,
       showSymbol: false,
       lineStyle: {
-        color: (p: { dataIndex: number }) => {
-          const i = p.dataIndex;
-          if (i >= values.length - 1) return "#000";
-          return values[i + 1] >= values[i] ? "#000" : "#f00";
-        }
+        color: trendColor(values)
       }
     });
 

--- a/sales-drilldown/src/utils/trendColor.ts
+++ b/sales-drilldown/src/utils/trendColor.ts
@@ -1,0 +1,7 @@
+export function trendColor(values: number[]) {
+  return (p: { dataIndex: number }) => {
+    const i = p.dataIndex;
+    if (i >= values.length - 1) return "#000";
+    return values[i + 1] >= values[i] ? "#000" : "#f00";
+  };
+}


### PR DESCRIPTION
## Summary
- centralize trend-based line coloring utility
- apply dynamic coloring across chart components so rising segments are black and declines red

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c19f605b0c832896bf6afb29ee7320