### PR TITLE
fix: color downtrends red

### DIFF
--- a/sales-drilldown/src/utils/trendColor.ts
+++ b/sales-drilldown/src/utils/trendColor.ts
@@ -1,7 +1,7 @@
 export function trendColor(values: number[]) {
   return (p: { dataIndex: number }) => {
     const i = p.dataIndex;
-    if (i >= values.length - 1) return "#000";
-    return values[i + 1] >= values[i] ? "#000" : "#f00";
+    if (i <= 0) return "#000";
+    return values[i] >= values[i - 1] ? "#000" : "#f00";
   };
 }


### PR DESCRIPTION
## Summary
- ensure trend color checks prior value so downward segments render red

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c89dc1a483288d18cdcb6036db53