### PR TITLE
Color line chart segments by trend

### DIFF
--- a/sales-drilldown/src/components/DeepMetricPanel.tsx
+++ b/sales-drilldown/src/components/DeepMetricPanel.tsx
@@ -55,10 +55,11 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
   const option = useMemo(() => {
     if (view.level === "years") {
       const labels = view.years.map(y=>y.yearKey);
-      const data = view.years.map(y=>{
+      const values = view.years.map(y=>{
         const days = y.months.flatMap(m=> m.weeks.flatMap(w=> w.metrics));
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
+      const data = trendColor(values);
       return {
         title:{text: meta.label},
         tooltip:{trigger:"axis"},
@@ -70,19 +71,17 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     if (view.level === "quarters") {
       const labels = view.quarters.map(q=> q.quarterKey.split('-')[1]);
-      const data = view.quarters.map(q=>{
+      const values = view.quarters.map(q=>{
         const days = q.months.flatMap(m=> m.weeks.flatMap(w=> w.metrics));
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
+      const data = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.year.yearKey}`},
         tooltip:{trigger:"axis"},
@@ -94,19 +93,17 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     if (view.level === "months") {
       const labels = view.quarter.months.map(m=> monthShortLabel(m.monthKey));
-      const data = view.quarter.months.map(m=>{
+      const values = view.quarter.months.map(m=>{
         const days = m.weeks.flatMap(w=> w.metrics);
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
+      const data = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.quarter.quarterKey}`},
         tooltip:{trigger:"axis"},
@@ -118,19 +115,17 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     if (view.level === "weeks") {
       const labels = view.month.weeks.map(w=> w.week);
-      const data = view.month.weeks.map(w=>{
+      const values = view.month.weeks.map(w=>{
         const vals = w.metrics.map(d=>calcDay(d));
         return Number(aggregate(meta, vals).toFixed(meta.decimals ?? 0));
       });
+      const data = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.month.month}`},
         tooltip:{trigger:"axis"},
@@ -142,17 +137,15 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     if (view.level === "days") {
       const days = daysOfMonth(view.month);
       const labels = days.map(d=> d.dateISO.slice(8,10));
-      const data = days.map(d=> Number(calcDay(d.totals).toFixed(meta.decimals ?? 0)));
+      const values = days.map(d=> Number(calcDay(d.totals).toFixed(meta.decimals ?? 0)));
+      const data = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.month.month}`},
         tooltip:{trigger:"axis"},
@@ -165,17 +158,15 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     if (view.level === "hours") {
       const hours = synthesizeHours(view.dayISO, metric, view.dayTotal);
       const labels = hours.map(h=> String(h.hour));
-      const data = hours.map(h=> h.value);
+      const values = hours.map(h=> h.value);
+      const data = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.dayISO}`},
         tooltip:{trigger:"axis"},
@@ -186,16 +177,14 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
           type: "line",
           data,
           smooth:true,
-          showSymbol:false,
-          lineStyle:{
-            color: trendColor(data)
-          }
+          showSymbol:false
         }]
       } as echarts.EChartsCoreOption;
     }
     const minutes = synthesizeMinutes(view.dayISO, view.hour, metric, view.hourTotal);
     const labels = minutes.map(m=> String(m.minute));
-    const data = minutes.map(m=> m.value);
+    const values = minutes.map(m=> m.value);
+    const data = trendColor(values);
     return {
       title:{text: `${meta.label} — ${view.dayISO} ${String(view.hour).padStart(2,'0')}:00`},
       tooltip:{trigger:"axis"},
@@ -206,10 +195,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         type: "line",
         data,
         smooth:true,
-        showSymbol:false,
-        lineStyle:{
-          color: trendColor(data)
-        }
+        showSymbol:false
       }]
     } as echarts.EChartsCoreOption;
   }, [view, metric, meta, calcDay]);

--- a/sales-drilldown/src/components/IndependentMetricChart.tsx
+++ b/sales-drilldown/src/components/IndependentMetricChart.tsx
@@ -36,6 +36,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "years") {
       const labels = view.years.map((y) => y.yearKey);
       const values = view.years.map((y) => y.totals[metric]);
+      const data = trendColor(values);
       return {
         title: { text: meta.label },
         tooltip: { trigger: "axis" },
@@ -45,13 +46,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data: values,
+            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false,
-            lineStyle: {
-              color: trendColor(values)
-            }
+            showSymbol: false
           }
         ]
       } as EChartsOption;
@@ -59,6 +57,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "months") {
       const labels = view.year.months.map((m) => monthShortLabel(m.monthKey));
       const values = view.year.months.map((m) => m.totals[metric]);
+      const data = trendColor(values);
       return {
         title: { text: `${meta.label} — ${view.year.yearKey}` },
         tooltip: { trigger: "axis" },
@@ -68,13 +67,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data: values,
+            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false,
-            lineStyle: {
-              color: trendColor(values)
-            }
+            showSymbol: false
           }
         ]
       } as EChartsOption;
@@ -82,6 +78,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "weeks") {
       const labels = view.month.weeks.map((w) => w.week);
       const values = view.month.weeks.map((w) => w.totals[metric]);
+      const data = trendColor(values);
       return {
         title: { text: `${meta.label} — ${view.month.month}` },
         tooltip: { trigger: "axis" },
@@ -91,13 +88,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data: values,
+            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false,
-            lineStyle: {
-              color: trendColor(values)
-            }
+            showSymbol: false
           }
         ]
       } as EChartsOption;
@@ -106,6 +100,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     const week = view.month.weeks[view.weekIdx];
     const labels = week.metrics.map((d) => d.day);
     const values = week.metrics.map((d) => d[metric]);
+    const data = trendColor(values);
     return {
       title: { text: `${meta.label} — ${view.month.month} / ${week.week}` },
       tooltip: { trigger: "axis" },
@@ -115,13 +110,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
         {
           name: meta.label,
           type: "line",
-          data: values,
+          data,
           smooth: true,
           universalTransition: true,
-          showSymbol: false,
-          lineStyle: {
-            color: trendColor(values)
-          }
+          showSymbol: false
         }
       ]
     } as EChartsOption;

--- a/sales-drilldown/src/components/MetricChart.tsx
+++ b/sales-drilldown/src/components/MetricChart.tsx
@@ -42,6 +42,7 @@ export default function MetricChart({
     if (view.level === "months") {
       const labels = SALES.map((m) => m.month);
       const values = SALES.map((m) => m.totals[metric]);
+      const data = trendColor(values);
       return {
         title: { text: meta.label },
         tooltip: { trigger: "axis" },
@@ -51,13 +52,10 @@ export default function MetricChart({
           {
             name: meta.label,
             type: "line",
-            data: values,
+            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false,
-            lineStyle: {
-              color: trendColor(values)
-            }
+            showSymbol: false
           }
         ]
       } as EChartsOption;
@@ -67,6 +65,7 @@ export default function MetricChart({
       const { month } = view;
       const labels = month.weeks.map((w) => w.week);
       const totals = month.weeks.map((w) => w.totals[metric]);
+      const data = trendColor(totals);
       return {
         title: { text: `${meta.label} — ${month.month}` },
         tooltip: { trigger: "axis" },
@@ -76,13 +75,10 @@ export default function MetricChart({
           {
             name: meta.label,
             type: "line",
-            data: totals,
+            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false,
-            lineStyle: {
-              color: trendColor(totals)
-            }
+            showSymbol: false
           }
         ]
       } as EChartsOption;
@@ -93,6 +89,7 @@ export default function MetricChart({
     const week = month.weeks[weekIdx];
     const labels = week.metrics.map((d) => d.day);
     const vals = week.metrics.map((d) => d[metric]);
+    const data = trendColor(vals);
     return {
       title: { text: `${meta.label} — ${month.month} / ${week.week}` },
       tooltip: { trigger: "axis" },
@@ -102,13 +99,10 @@ export default function MetricChart({
         {
           name: meta.label,
           type: "line",
-          data: vals,
+          data,
           smooth: true,
           universalTransition: true,
-          showSymbol: false,
-          lineStyle: {
-            color: trendColor(vals)
-          }
+          showSymbol: false
         }
       ]
     } as EChartsOption;

--- a/sales-drilldown/src/components/SalesDrilldown.tsx
+++ b/sales-drilldown/src/components/SalesDrilldown.tsx
@@ -25,12 +25,9 @@ export default function SalesDrilldown() {
     const makeSeries = (name: string, values: number[]) => ({
       name,
       type: "line" as const,
-      data: values,
+      data: trendColor(values),
       smooth: true,
-      showSymbol: false,
-      lineStyle: {
-        color: trendColor(values)
-      }
+      showSymbol: false
     });
 
     if (view.level === "months") {

--- a/sales-drilldown/src/utils/trendColor.ts
+++ b/sales-drilldown/src/utils/trendColor.ts
@@ -1,7 +1,8 @@
 export function trendColor(values: number[]) {
-  return (p: { dataIndex: number }) => {
-    const i = p.dataIndex;
-    if (i <= 0) return "#000";
-    return values[i] >= values[i - 1] ? "#000" : "#f00";
-  };
+  return values.map((v, i) => ({
+    value: v,
+    lineStyle: {
+      color: i < values.length - 1 && values[i + 1] < v ? "#f00" : "#000"
+    }
+  }));
 }


### PR DESCRIPTION
## Summary
- color each line-chart segment red when the next point falls, black otherwise
- apply per-point line styling across drilldown chart components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f9bd68ac832894b3506e2e7a04b7