### PR TITLE
Remove demo route and refine trend coloring

### DIFF
--- a/sales-drilldown/src/utils/trendColor.ts
+++ b/sales-drilldown/src/utils/trendColor.ts
@@ -1,8 +1,28 @@
+const UP_COLOR = "#000";
+const DOWN_COLOR = "#c21";
+
+/**
+ * Build ECharts-friendly data items that color each line segment based on the
+ * movement from the previous point. Segments with a non-negative change use
+ * {@link UP_COLOR}, while negative deltas use {@link DOWN_COLOR}.
+ */
 export function trendColor(values: number[]) {
-  return values.map((v, i) => ({
-    value: v,
-    lineStyle: {
-      color: i < values.length - 1 && values[i + 1] < v ? "#f00" : "#000"
-    }
-  }));
+  return values.map((value, index) => {
+    const color = getSegmentColor(values, index);
+    return {
+      value,
+      lineStyle: { color },
+      itemStyle: { color }
+    };
+  });
+}
+
+function getSegmentColor(values: number[], index: number) {
+  if (index === 0) {
+    const next = values[1];
+    if (typeof next === "number" && next < values[0]) return DOWN_COLOR;
+    return UP_COLOR;
+  }
+  const prev = values[index - 1];
+  return values[index] < prev ? DOWN_COLOR : UP_COLOR;
 }


### PR DESCRIPTION
## Summary
- remove the standalone `/echarts` page and its helper files so the dashboard only exposes the existing views
- drop the unused fullscreen print stylesheet from the root layout import
- update the shared `trendColor` helper to color each segment and marker based on the previous movement

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8919d98988328839314ea474c9d09