### PR TITLE
Fix ECharts trend coloring for line segments

### DIFF
--- a/sales-drilldown/src/components/DeepMetricPanel.tsx
+++ b/sales-drilldown/src/components/DeepMetricPanel.tsx
@@ -59,7 +59,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         const days = y.months.flatMap(m=> m.weeks.flatMap(w=> w.metrics));
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: meta.label},
         tooltip:{trigger:"axis"},
@@ -68,10 +68,10 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
@@ -81,7 +81,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         const days = q.months.flatMap(m=> m.weeks.flatMap(w=> w.metrics));
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.year.yearKey}`},
         tooltip:{trigger:"axis"},
@@ -90,10 +90,10 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
@@ -103,7 +103,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         const days = m.weeks.flatMap(w=> w.metrics);
         return Number(aggregate(meta, days.map(d=>calcDay(d))).toFixed(meta.decimals ?? 0));
       });
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.quarter.quarterKey}`},
         tooltip:{trigger:"axis"},
@@ -112,10 +112,10 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
@@ -125,7 +125,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         const vals = w.metrics.map(d=>calcDay(d));
         return Number(aggregate(meta, vals).toFixed(meta.decimals ?? 0));
       });
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.month.month}`},
         tooltip:{trigger:"axis"},
@@ -134,10 +134,10 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
@@ -145,7 +145,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
       const days = daysOfMonth(view.month);
       const labels = days.map(d=> d.dateISO.slice(8,10));
       const values = days.map(d=> Number(calcDay(d.totals).toFixed(meta.decimals ?? 0)));
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.month.month}`},
         tooltip:{trigger:"axis"},
@@ -155,10 +155,10 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
           universalTransition:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
@@ -166,7 +166,7 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
       const hours = synthesizeHours(view.dayISO, metric, view.dayTotal);
       const labels = hours.map(h=> String(h.hour));
       const values = hours.map(h=> h.value);
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title:{text: `${meta.label} — ${view.dayISO}`},
         tooltip:{trigger:"axis"},
@@ -175,16 +175,16 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
         series:[{
           name: meta.label,
           type: "line",
-          data,
           smooth:true,
-          showSymbol:false
+          showSymbol:false,
+          ...trend
         }]
       } as echarts.EChartsCoreOption;
     }
     const minutes = synthesizeMinutes(view.dayISO, view.hour, metric, view.hourTotal);
     const labels = minutes.map(m=> String(m.minute));
     const values = minutes.map(m=> m.value);
-    const data = trendColor(values);
+    const trend = trendColor(values);
     return {
       title:{text: `${meta.label} — ${view.dayISO} ${String(view.hour).padStart(2,'0')}:00`},
       tooltip:{trigger:"axis"},
@@ -193,9 +193,9 @@ export default function DeepMetricPanel({ metric }: { metric: MetricKey }) {
       series:[{
         name: meta.label,
         type: "line",
-        data,
         smooth:true,
-        showSymbol:false
+        showSymbol:false,
+        ...trend
       }]
     } as echarts.EChartsCoreOption;
   }, [view, metric, meta, calcDay]);

--- a/sales-drilldown/src/components/IndependentMetricChart.tsx
+++ b/sales-drilldown/src/components/IndependentMetricChart.tsx
@@ -36,7 +36,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "years") {
       const labels = view.years.map((y) => y.yearKey);
       const values = view.years.map((y) => y.totals[metric]);
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title: { text: meta.label },
         tooltip: { trigger: "axis" },
@@ -46,10 +46,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false
+            showSymbol: false,
+            ...trend
           }
         ]
       } as EChartsOption;
@@ -57,7 +57,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "months") {
       const labels = view.year.months.map((m) => monthShortLabel(m.monthKey));
       const values = view.year.months.map((m) => m.totals[metric]);
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title: { text: `${meta.label} — ${view.year.yearKey}` },
         tooltip: { trigger: "axis" },
@@ -67,10 +67,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false
+            showSymbol: false,
+            ...trend
           }
         ]
       } as EChartsOption;
@@ -78,7 +78,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     if (view.level === "weeks") {
       const labels = view.month.weeks.map((w) => w.week);
       const values = view.month.weeks.map((w) => w.totals[metric]);
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title: { text: `${meta.label} — ${view.month.month}` },
         tooltip: { trigger: "axis" },
@@ -88,10 +88,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
           {
             name: meta.label,
             type: "line",
-            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false
+            showSymbol: false,
+            ...trend
           }
         ]
       } as EChartsOption;
@@ -100,7 +100,7 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
     const week = view.month.weeks[view.weekIdx];
     const labels = week.metrics.map((d) => d.day);
     const values = week.metrics.map((d) => d[metric]);
-    const data = trendColor(values);
+    const trend = trendColor(values);
     return {
       title: { text: `${meta.label} — ${view.month.month} / ${week.week}` },
       tooltip: { trigger: "axis" },
@@ -110,10 +110,10 @@ export default function IndependentMetricChart({ metric }: { metric: Metric }) {
         {
           name: meta.label,
           type: "line",
-          data,
           smooth: true,
           universalTransition: true,
-          showSymbol: false
+          showSymbol: false,
+          ...trend
         }
       ]
     } as EChartsOption;

--- a/sales-drilldown/src/components/MetricChart.tsx
+++ b/sales-drilldown/src/components/MetricChart.tsx
@@ -42,7 +42,7 @@ export default function MetricChart({
     if (view.level === "months") {
       const labels = SALES.map((m) => m.month);
       const values = SALES.map((m) => m.totals[metric]);
-      const data = trendColor(values);
+      const trend = trendColor(values);
       return {
         title: { text: meta.label },
         tooltip: { trigger: "axis" },
@@ -52,10 +52,10 @@ export default function MetricChart({
           {
             name: meta.label,
             type: "line",
-            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false
+            showSymbol: false,
+            ...trend
           }
         ]
       } as EChartsOption;
@@ -65,7 +65,7 @@ export default function MetricChart({
       const { month } = view;
       const labels = month.weeks.map((w) => w.week);
       const totals = month.weeks.map((w) => w.totals[metric]);
-      const data = trendColor(totals);
+      const trend = trendColor(totals);
       return {
         title: { text: `${meta.label} — ${month.month}` },
         tooltip: { trigger: "axis" },
@@ -75,10 +75,10 @@ export default function MetricChart({
           {
             name: meta.label,
             type: "line",
-            data,
             smooth: true,
             universalTransition: true,
-            showSymbol: false
+            showSymbol: false,
+            ...trend
           }
         ]
       } as EChartsOption;
@@ -89,7 +89,7 @@ export default function MetricChart({
     const week = month.weeks[weekIdx];
     const labels = week.metrics.map((d) => d.day);
     const vals = week.metrics.map((d) => d[metric]);
-    const data = trendColor(vals);
+    const trend = trendColor(vals);
     return {
       title: { text: `${meta.label} — ${month.month} / ${week.week}` },
       tooltip: { trigger: "axis" },
@@ -99,10 +99,10 @@ export default function MetricChart({
         {
           name: meta.label,
           type: "line",
-          data,
           smooth: true,
           universalTransition: true,
-          showSymbol: false
+          showSymbol: false,
+          ...trend
         }
       ]
     } as EChartsOption;

--- a/sales-drilldown/src/components/SalesDrilldown.tsx
+++ b/sales-drilldown/src/components/SalesDrilldown.tsx
@@ -25,9 +25,9 @@ export default function SalesDrilldown() {
     const makeSeries = (name: string, values: number[]) => ({
       name,
       type: "line" as const,
-      data: trendColor(values),
       smooth: true,
-      showSymbol: false
+      showSymbol: false,
+      ...trendColor(values)
     });
 
     if (view.level === "months") {

--- a/sales-drilldown/src/utils/trendColor.ts
+++ b/sales-drilldown/src/utils/trendColor.ts
@@ -1,20 +1,33 @@
+import type { CallbackDataParams } from "echarts/types/dist/shared";
+import type { LineSeriesOption } from "echarts/charts";
+
 const UP_COLOR = "#000";
 const DOWN_COLOR = "#c21";
 
+type TrendSeriesConfig = Pick<LineSeriesOption, "data" | "lineStyle" | "itemStyle" | "emphasis">;
+
 /**
- * Build ECharts-friendly data items that color each line segment based on the
- * movement from the previous point. Segments with a non-negative change use
- * {@link UP_COLOR}, while negative deltas use {@link DOWN_COLOR}.
+ * Build the reusable series configuration that colors each line segment based on
+ * how the value changed from the previous point. Segments with a non-negative
+ * change use {@link UP_COLOR}, while negative deltas use {@link DOWN_COLOR}.
  */
-export function trendColor(values: number[]) {
-  return values.map((value, index) => {
-    const color = getSegmentColor(values, index);
-    return {
-      value,
-      lineStyle: { color },
-      itemStyle: { color }
-    };
-  });
+export function trendColor(values: number[]): TrendSeriesConfig {
+  const safeValues = values.slice();
+
+  const colorForParams = (params: CallbackDataParams) => {
+    const index = typeof params.dataIndex === "number" ? params.dataIndex : 0;
+    return getSegmentColor(safeValues, clampIndex(index, safeValues.length));
+  };
+
+  return {
+    data: safeValues,
+    lineStyle: { color: colorForParams },
+    itemStyle: { color: colorForParams },
+    emphasis: {
+      lineStyle: { color: colorForParams },
+      itemStyle: { color: colorForParams }
+    }
+  };
 }
 
 function getSegmentColor(values: number[], index: number) {
@@ -25,4 +38,10 @@ function getSegmentColor(values: number[], index: number) {
   }
   const prev = values[index - 1];
   return values[index] < prev ? DOWN_COLOR : UP_COLOR;
+}
+
+function clampIndex(index: number, length: number) {
+  if (index < 0) return 0;
+  if (index >= length) return length - 1;
+  return index;
 }


### PR DESCRIPTION
## Summary
- update the trendColor utility to return line and item style callbacks so each segment reflects its up/down trend color
- use the new trend-aware configuration in SalesDrilldown, MetricChart, IndependentMetricChart, and DeepMetricPanel so chart lines inherit the dynamic styling while keeping transitions and interactions intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c2d0bfbc8328abf2292780930061